### PR TITLE
Back link url pointing to Applications page

### DIFF
--- a/server/views/pages/log/application-type.njk
+++ b/server/views/pages/log/application-type.njk
@@ -12,7 +12,7 @@
   <div class="govuk-body govuk-width-container">
   {{ govukBackLink({
       text: "Back",
-      href: "#"
+      href: "/"
      }) }}
    
   <span class="govuk-caption-xl">Log an application</span>


### PR DESCRIPTION
A small fix to a href for back link on application type page. 
[RA-190](https://dsdmoj.atlassian.net/browse/RA-190)
AC2 - Back link to ‘Applications’ page

[RA-190]: https://dsdmoj.atlassian.net/browse/RA-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ