### PR TITLE
A small fix to ensure inset text is retained regardless of lookup result

### DIFF
--- a/server/views/pages/log-application/prisoner-details/index.njk
+++ b/server/views/pages/log-application/prisoner-details/index.njk
@@ -82,8 +82,12 @@
             </button>
           </div>
 
-          {% if prisonerName %}
-            {% set insetText = "Prisoner name: " + prisonerName %}
+          {% if prisonerName or prisonerLookupButton == 'true' %}
+            {% if prisonerName %}
+              {% set insetText = "Prisoner name: " + prisonerName %}
+            {% else %}
+              {% set insetText = "Prisoner name: Not found" %}
+            {% endif %}  
             {% set insetClasses = "govuk-!-margin-top-0" %}
           {% else %}
             {% set insetText = "" %}


### PR DESCRIPTION
Fix to ensure 'Prisoner name: Not found' message remains visible