### PR TITLE
RA-524:validate telephone number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "helmet": "^8.1.0",
         "http-errors": "^2.0.0",
         "jwt-decode": "^4.0.0",
+        "libphonenumber-js": "^1.12.10",
         "nocache": "^4.0.0",
         "nunjucks": "^3.2.4",
         "passport": "^0.7.0",
@@ -11189,6 +11190,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.10",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.10.tgz",
+      "integrity": "sha512-E91vHJD61jekHHR/RF/E83T/CMoaLXT7cwYA75T4gim4FZjnM6hbJjVIGg7chqlSqRsSvQ3izGmOjHy1SQzcGQ=="
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "helmet": "^8.1.0",
     "http-errors": "^2.0.0",
     "jwt-decode": "^4.0.0",
+    "libphonenumber-js": "^1.12.10",
     "nocache": "^4.0.0",
     "nunjucks": "^3.2.4",
     "passport": "^0.7.0",

--- a/server/routes/validate/validateNewSocialPinPhoneContact.ts
+++ b/server/routes/validate/validateNewSocialPinPhoneContact.ts
@@ -1,3 +1,5 @@
+import { isValidPhoneNumber } from './validateTelephoneNumber'
+
 export type AddNewSocialPinPhoneContactForm = {
   firstName: string
   lastName: string
@@ -8,10 +10,10 @@ export type AddNewSocialPinPhoneContactForm = {
   age?: string
   relationship: string
   telephone1: string
+  telephone2?: string
 }
 
 const isValidNumber = (value: string) => /^\d+$/.test(value)
-const isValidPhoneNumber = (value: string) => /^[\d+\-()\s]+$/.test(value)
 
 export const validateAddNewSocialContact = (form: AddNewSocialPinPhoneContactForm) => {
   const errors: Record<string, { text: string }> = {}
@@ -76,6 +78,10 @@ export const validateAddNewSocialContact = (form: AddNewSocialPinPhoneContactFor
 
   if (!form.telephone1 || form.telephone1.trim() === '' || !isValidPhoneNumber(form.telephone1.trim())) {
     errors.telephone1 = { text: 'Enter the contact’s phone number' }
+  }
+
+  if (form.telephone2 && form.telephone2.trim() !== '' && !isValidPhoneNumber(form.telephone2.trim())) {
+    errors.telephone2 = { text: 'Enter the contact’s phone number' }
   }
 
   return errors

--- a/server/routes/validate/validateTelephoneNumber.test.ts
+++ b/server/routes/validate/validateTelephoneNumber.test.ts
@@ -1,0 +1,86 @@
+import { sanitisePhoneNumber, isValidPhoneNumber } from './validateTelephoneNumber'
+
+describe('sanitisePhoneNumber', () => {
+  it('returns null if input is empty or contains + symbol', () => {
+    expect(sanitisePhoneNumber('')).toBeNull()
+    expect(sanitisePhoneNumber('+1234567890')).toBeNull()
+  })
+
+  it('strips invalid characters but keeps digits and brackets, parses extension', () => {
+    expect(sanitisePhoneNumber('1-212-456-7890(1234)')).toEqual({
+      mainNumber: '12124567890',
+      extension: '1234',
+    })
+    expect(sanitisePhoneNumber('(123) 456 7890')).toEqual({
+      mainNumber: '(123)4567890',
+      extension: null,
+    })
+    expect(sanitisePhoneNumber('123 456 7890')).toEqual({
+      mainNumber: '1234567890',
+      extension: null,
+    })
+    expect(sanitisePhoneNumber('123456 ext123')).toEqual({
+      mainNumber: '123456',
+      extension: '123',
+    })
+    expect(sanitisePhoneNumber('123456 extension 4567')).toEqual({
+      mainNumber: '123456',
+      extension: '4567',
+    })
+    expect(sanitisePhoneNumber('123456 EXTENSION4567')).toEqual({
+      mainNumber: '123456',
+      extension: '4567',
+    })
+    expect(sanitisePhoneNumber('123456 EXT4567')).toEqual({
+      mainNumber: '123456',
+      extension: '4567',
+    })
+    expect(sanitisePhoneNumber('123456 x4567')).toEqual({
+      mainNumber: '123456',
+      extension: '4567',
+    })
+  })
+
+  it('returns null if main number length is less than 6 or more than 40', () => {
+    expect(sanitisePhoneNumber('12345')).toBeNull()
+    expect(sanitisePhoneNumber('1'.repeat(41))).toBeNull()
+  })
+
+  it('returns null for invalid patterns', () => {
+    expect(sanitisePhoneNumber('abc def ghi')).toBeNull()
+    expect(sanitisePhoneNumber('12345x123')).toBeNull()
+    expect(sanitisePhoneNumber('(123)45')).toBeNull()
+  })
+})
+
+describe('isValidPhoneNumber', () => {
+  it('returns false for invalid or empty inputs', () => {
+    expect(isValidPhoneNumber('')).toBe(false)
+    expect(isValidPhoneNumber('+1234567890')).toBe(false)
+    expect(isValidPhoneNumber('abc def')).toBe(false)
+    expect(isValidPhoneNumber('12345')).toBe(false)
+  })
+
+  it('returns true for valid numbers without extension', () => {
+    expect(isValidPhoneNumber('020 7946 0018')).toBe(true)
+    expect(isValidPhoneNumber('(020) 7946 0018')).toBe(true)
+    expect(isValidPhoneNumber('12124567890')).toBe(true)
+  })
+
+  it('returns true for valid numbers with valid extension', () => {
+    expect(isValidPhoneNumber('1-212-456-7890(1234)')).toBe(true)
+    expect(isValidPhoneNumber('1-212-456-7890 ext1234')).toBe(true)
+    expect(isValidPhoneNumber('1-212-456-7890 EXTENSION1234')).toBe(true)
+    expect(isValidPhoneNumber('1-212-456-7890 x1234')).toBe(true)
+  })
+
+  it('returns false for invalid extensions', () => {
+    expect(isValidPhoneNumber('1-212-456-7890 ext12345678')).toBe(false)
+    expect(isValidPhoneNumber('1-212-456-7890 ext12a4')).toBe(false)
+  })
+
+  it('returns false if main number is longer than 15 digits (libphonenumber limit)', () => {
+    const longNumber = '1'.repeat(16)
+    expect(isValidPhoneNumber(longNumber)).toBe(false)
+  })
+})

--- a/server/routes/validate/validateTelephoneNumber.ts
+++ b/server/routes/validate/validateTelephoneNumber.ts
@@ -1,0 +1,43 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
+
+export const sanitisePhoneNumber = (input: string): { mainNumber: string; extension: string | null } | null => {
+  if (!input || input.includes('+')) return null
+
+  const trimmed = input.trim()
+  const regex = /^(.+?)\s*(?:\(?\s*(?:ext\.?|extension|x)\.?\s*(\d{1,7})\s*\)?|\((\d{1,7})\))?$/i
+  const match = trimmed.match(regex)
+
+  if (!match) return null
+
+  const mainNumber = match[1].replace(/[^0-9()]/g, '')
+  const extension = match[2] ?? match[3] ?? null
+  const digitCount = mainNumber.replace(/[^0-9]/g, '').length
+  if (digitCount < 6 || digitCount > 40) return null
+
+  return { mainNumber, extension }
+}
+
+export const isValidPhoneNumber = (input: string): boolean => {
+  const sanitisedResult = sanitisePhoneNumber(input)
+  if (!sanitisedResult) return false
+
+  const { mainNumber, extension } = sanitisedResult
+
+  const digitsOnly = mainNumber.replace(/[()]/g, '')
+
+  let parsed
+
+  if (digitsOnly.startsWith('00')) {
+    parsed = parsePhoneNumberFromString(digitsOnly.replace(/^00/, '+'))
+  } else if (/^[1-9]\d{7,}$/.test(digitsOnly)) {
+    parsed = parsePhoneNumberFromString(`+${digitsOnly}`)
+  } else {
+    parsed = parsePhoneNumberFromString(digitsOnly, 'GB')
+  }
+
+  if (extension && !/^\d{1,7}$/.test(extension)) {
+    return false
+  }
+
+  return parsed?.isValid() ?? false
+}

--- a/server/views/pages/applications/change/partials/add-social-pin-phone-contact.njk
+++ b/server/views/pages/applications/change/partials/add-social-pin-phone-contact.njk
@@ -226,6 +226,7 @@
   id: "telephone2",
   name: "telephone2",
   inputmode: "numeric",
+  errorMessage: errors.telephone2,
   value: telephone2,
   spellcheck: false
 }) }}

--- a/server/views/pages/applications/change/partials/errors.njk
+++ b/server/views/pages/applications/change/partials/errors.njk
@@ -56,6 +56,10 @@
       {% set errorList = errorList.concat([{ text: errors.telephone1.text, href: "#telephone1" }]) %}
     {% endif %}
 
+    {% if errors.telephone2 %}
+      {% set errorList = errorList.concat([{ text: errors.telephone2.text, href: "#telephone2" }]) %}
+    {% endif %}
+
     {{ govukErrorSummary({
       titleText: "There is a problem",
       errorList: errorList

--- a/server/views/pages/log-application/application-details/partials/add-social-pin-phone-contact.njk
+++ b/server/views/pages/log-application/application-details/partials/add-social-pin-phone-contact.njk
@@ -226,6 +226,7 @@
   id: "telephone2",
   name: "telephone2",
   inputmode: "numeric",
+  errorMessage: errors.telephone2,
   value: telephone2,
   spellcheck: false
 }) }}

--- a/server/views/pages/log-application/application-details/partials/errors.njk
+++ b/server/views/pages/log-application/application-details/partials/errors.njk
@@ -44,6 +44,10 @@
       {% set errorList = errorList.concat([{ text: errors.telephone1.text, href: "#telephone1" }]) %}
     {% endif %}
 
+    {% if errors.telephone2 %}
+      {% set errorList = errorList.concat([{ text: errors.telephone2.text, href: "#telephone2" }]) %}
+    {% endif %}
+
     {{ govukErrorSummary({
       titleText: "There is a problem",
       errorList: errorList


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/RA-524

Uses _libphonenumber-js_ to validate telephone numbers based on country-specific rules (e.g., length, format).
The library automatically detects the country from the number or defaults to GB.
It rejects numbers that exceed the valid length for that country code.

Added unit test as well

Examples of valid inputs:
020 7946 0018
(020) 7946 0018
12124567890 ext1234
441234567890(123)
1-212-456-7890 extension1234

