### PR TITLE
RA-668: Fix to support legacy company field for old applications

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -76,7 +76,7 @@ export declare module 'express-session' {
   interface AddNewOfficialPinPhoneContactDetails {
     firstName: string
     lastName: string
-    organisation: string
+    organisation?: string
     relationship: string
     telephone1: string
     telephone2?: string

--- a/server/routes/applications/changeApplicationRoutes.ts
+++ b/server/routes/applications/changeApplicationRoutes.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from 'express'
+import { AddNewOfficialPinPhoneContactDetails } from 'express-session'
 
 import { PATHS } from '../../constants/paths'
 import { URLS } from '../../constants/urls'
@@ -144,7 +145,14 @@ export default function changeApplicationRoutes({
 
       const payload = {
         firstNightCenter: applicationData?.earlyDaysCentre === 'yes',
-        formData: [{ ...(applicationData?.additionalData as Record<string, unknown>), id: application.requests[0].id }],
+        formData: [
+          {
+            ...(applicationData?.additionalData as Record<string, unknown>),
+            company:
+              (applicationData?.additionalData as Partial<AddNewOfficialPinPhoneContactDetails>).organisation || '',
+            id: application.requests[0].id,
+          },
+        ],
       }
 
       await managingPrisonerAppsService.changeApp(prisonerId, applicationId, payload, user)

--- a/server/routes/applications/viewApplicationsRoutes.ts
+++ b/server/routes/applications/viewApplicationsRoutes.ts
@@ -201,6 +201,10 @@ export default function viewApplicationRoutes({
         },
         isClosed: application.status !== APPLICATION_STATUS.PENDING,
         dpsPrisonerUrl: config.dpsPrisoner,
+        organisation:
+          (application?.requests?.[0] as Partial<{ organisation?: string; company?: string }>)?.organisation?.trim() ||
+          (application?.requests?.[0] as Partial<{ organisation?: string; company?: string }>)?.company?.trim() ||
+          '',
       })
     }),
   )

--- a/server/utils/getAppDetails.ts
+++ b/server/utils/getAppDetails.ts
@@ -60,11 +60,15 @@ export default async function getApplicationDetails(
 
     case 'PIN_PHONE_ADD_NEW_OFFICIAL_CONTACT': {
       const request = (application?.requests?.[0] as AddNewOfficialContactRequest) ?? {}
+      const requestWithCompany = request as AddNewOfficialContactRequest & { company?: string }
+      const applicationDetailsWithCompany = applicationDetails as AddNewOfficialContactRequest & { company?: string }
 
       const prefilledDetails: AddNewOfficialContactRequest = {
         firstName: getFallbackValue('firstName', applicationDetails, request, ''),
         lastName: getFallbackValue('lastName', applicationDetails, request, ''),
-        organisation: getFallbackValue('organisation', applicationDetails, request, ''),
+        organisation:
+          getFallbackValue('organisation', applicationDetailsWithCompany, requestWithCompany, '') ||
+          getFallbackValue('company', applicationDetailsWithCompany, requestWithCompany, ''),
         relationship: getFallbackValue('relationship', applicationDetails, request, ''),
         telephone1: getFallbackValue('telephone1', applicationDetails, request, ''),
         telephone2: getFallbackValue('telephone2', applicationDetails, request, ''),

--- a/server/utils/getAppTypeLogDetails.ts
+++ b/server/utils/getAppTypeLogDetails.ts
@@ -45,7 +45,7 @@ export type AddNewOfficialContactAppType = {
   type: 'PIN_PHONE_ADD_NEW_OFFICIAL_CONTACT'
   firstName: string
   lastName: string
-  organisation: string
+  organisation?: string
   relationship: string
   telephone1: string
   telephone2?: string
@@ -74,17 +74,18 @@ export function getAppTypeLogDetailsData(applicationType: ApplicationType, addit
       const {
         firstName = '',
         lastName = '',
-        organisation = '',
+        organisation,
+        company,
         relationship = '',
         telephone1 = '',
         telephone2 = '',
-      } = additionalData as AddNewOfficialPinPhoneContactDetails
+      } = additionalData as AddNewOfficialPinPhoneContactDetails & { company?: string }
 
       return {
         type: 'PIN_PHONE_ADD_NEW_OFFICIAL_CONTACT',
         firstName,
         lastName,
-        organisation,
+        organisation: organisation || company || '',
         relationship,
         telephone1,
         telephone2,

--- a/server/views/pages/applications/view/partials/add-official-pin-phone-contact.njk
+++ b/server/views/pages/applications/view/partials/add-official-pin-phone-contact.njk
@@ -1,5 +1,6 @@
 {{ appTypeSummaryListHeader("New official contact to add", application.requestedBy.username, application.id, isClosed) }}
 
+
 {% set rows = [] %}
 
 {% set _ = rows.push({
@@ -14,7 +15,7 @@
 
 {% set _ = rows.push({
   key: { text: "Organisation" },
-  value: { text: application.requests[0].organisation }
+  value: { text: organisation }
 }) %}
 
 {% set _ = rows.push({


### PR DESCRIPTION
This PR contains
We renamed `company` to `organisation` as per 
https://dsdmoj.atlassian.net/browse/RA-668.
However, older application records still use the company field. This fix ensures that both company (legacy) and organisation (new) fields are supported **when displaying or updating existing data.**
