### PR TITLE
enabling log method page for leeds establishment

### DIFF
--- a/server/constants/enabledEstablishments.ts
+++ b/server/constants/enabledEstablishments.ts
@@ -1,4 +1,4 @@
-export const LOG_METHOD_ENABLED_ESTABLISHMENTS: ReadonlyArray<string> = ['HMI']
+export const LOG_METHOD_ENABLED_ESTABLISHMENTS: ReadonlyArray<string> = ['HMI', 'LEI']
 
 export const isLogMethodEnabledEstablishment = (activeCaseLoadId?: string): boolean =>
   Boolean(activeCaseLoadId && LOG_METHOD_ENABLED_ESTABLISHMENTS.includes(activeCaseLoadId))


### PR DESCRIPTION
This PR is to enabling the Log method page for Leeds establishment and thereby they can use scanning image feature during logging journey.