### PR TITLE
RA-1039 | Application History.spec.ts

### DIFF
--- a/integration_tests/mockApis/managingPrisonerApps.ts
+++ b/integration_tests/mockApis/managingPrisonerApps.ts
@@ -67,7 +67,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        url: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/responses/${app.requests[0].responseId}?createdBy=true`,
+        urlPathPattern: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/responses/.*`,
       },
       response: {
         status: 200,
@@ -127,7 +127,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        url: `/managingPrisonerApps/v1/applications/${app.requestedBy.username}/apps/${app.id}/history`,
+        url: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/history`,
       },
       response: {
         status: 200,

--- a/integration_tests/playwright_tests/e2e/application-history.spec.ts
+++ b/integration_tests/playwright_tests/e2e/application-history.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '../fixtures'
+import { app } from '../../../server/testData'
+import ApplicationHistoryPage from '../pages/applicationHistoryPage'
+import Page from '../pages/page'
+import auth from '../../mockApis/auth'
+import managingPrisonerAppsApi from '../../mockApis/managingPrisonerApps'
+import prisonApi from '../../mockApis/prison'
+import { resetStubs } from '../../mockApis/wiremock'
+
+const targetBaseUrl = process.env.PW_BASE_URL || process.env.DPS_PRISONER_URL || 'http://localhost:3007'
+const isWiremock = process.env.PW_ENV === 'mock' || targetBaseUrl.includes('localhost')
+
+test.describe('Application History Page', () => {
+  test.beforeEach(async ({ page, signIn }) => {
+    if (isWiremock) {
+      await resetStubs()
+      await auth.stubSignIn()
+      await prisonApi.stubGetCaseLoads()
+      await managingPrisonerAppsApi.stubGetPrisonerApp({ app })
+      await managingPrisonerAppsApi.stubGetComments({ app })
+      await managingPrisonerAppsApi.stubGetHistory({ app })
+      await managingPrisonerAppsApi.stubGetAppResponse({ app })
+      await managingPrisonerAppsApi.stubGetGroupsAndTypes()
+    }
+
+    await signIn()
+    await page.goto(`/applications/${app.requestedBy.username}/${app.id}/history`)
+  })
+
+  test('should display the page title', async ({ page }) => {
+    const historyPage = await Page.verifyOnPage(ApplicationHistoryPage, page)
+    await expect(historyPage.pageTitle()).toContainText('History')
+  })
+
+  test('should display the History section', async ({ page }) => {
+    const historyPage = await Page.verifyOnPage(ApplicationHistoryPage, page)
+    await expect(historyPage.historyTab()).toBeVisible()
+    await expect(historyPage.historyTab()).toContainText('History')
+    await expect(historyPage.historyTab()).toHaveAttribute(
+      'href',
+      `/applications/${app.requestedBy.username}/${app.id}/history`,
+    )
+  })
+
+  test('should display the application type name in the caption', async ({ page }) => {
+    const historyPage = await Page.verifyOnPage(ApplicationHistoryPage, page)
+    await expect(historyPage.pageCaption()).toContainText('Add a social PIN phone contact')
+  })
+
+  test('should display the history page content', async ({ page }) => {
+    const historyPage = await Page.verifyOnPage(ApplicationHistoryPage, page)
+    await expect(historyPage.historyContent()).toBeVisible()
+  })
+})

--- a/integration_tests/playwright_tests/pages/applicationHistoryPage.ts
+++ b/integration_tests/playwright_tests/pages/applicationHistoryPage.ts
@@ -1,0 +1,28 @@
+import { type Page as PlaywrightPage, expect } from '@playwright/test'
+import Page, { type PageElement } from './page'
+
+export default class ApplicationHistoryPage extends Page {
+  constructor(page: PlaywrightPage) {
+    super(page, 'History')
+  }
+
+  async assertBrowserTitleContains(text: string): Promise<void> {
+    await expect(this.page).toHaveTitle(new RegExp(text))
+  }
+
+  pageTitle(): PageElement {
+    return this.page.locator('h1')
+  }
+
+  historyTab(): PageElement {
+    return this.page.locator('.moj-sub-navigation__link:has-text("History")')
+  }
+
+  pageCaption(): PageElement {
+    return this.page.locator('.govuk-caption-xl')
+  }
+
+  historyContent(): PageElement {
+    return this.page.getByText('History of this application')
+  }
+}


### PR DESCRIPTION
Add Application History page and update API stubs for history retrieval

Feature: Application history page
  As a prison staff user
  I want to view the history page for an application
  So that I can review previous actions and updates

  Background:
    Given I am signed in to the staff UI
    And an application exists for prisoner "G123456" with id "13d2c453-be11-44a8-9861-21fd8ae6e911"
    When I navigate to "/applications/G123456/13d2c453-be11-44a8-9861-21fd8ae6e911/history"

  Scenario: Display the page title
    Then I should see the page heading "History"

  Scenario: Display the History tab
    Then I should see a sub-navigation tab "History"
    And the "History" tab should link to "/applications/G123456/13d2c453-be11-44a8-9861-21fd8ae6e911/history"

  Scenario: Display the application type in the caption
    Then I should see the caption "Add a social PIN phone contact"

  Scenario: Display history page content
    Then I should see the text "History of this application"

<img width="1066" height="878" alt="Screenshot 2026-04-24 at 14 44 18" src="https://github.com/user-attachments/assets/b06b68fb-d3c4-4f51-b462-9d453be78c1c" />
<img width="995" height="886" alt="Screenshot 2026-04-24 at 14 44 12" src="https://github.com/user-attachments/assets/86c838c4-d942-4ce2-a365-34ca8f267b67" />
