### PR TITLE
RA-1140: manage apps entry - enforce active caseload check

### DIFF
--- a/integration_tests/fixtures/index.ts
+++ b/integration_tests/fixtures/index.ts
@@ -1,5 +1,6 @@
 import { Page, test as base } from '@playwright/test'
 import auth from '../mockApis/auth'
+import managingPrisonerAppsApi from '../mockApis/managingPrisonerApps'
 import prisonApi from '../mockApis/prison'
 import { resetStubs } from '../mockApis/wiremock'
 
@@ -94,6 +95,7 @@ export const test = base.extend<Fixtures>({
       if (isLocalhost) {
         // Fallback stub so tests that forget caseLoads still sign in; test-specific stubs can override.
         await prisonApi.stubGetCaseLoads('HMI', 100)
+        await managingPrisonerAppsApi.stubGetActiveAgencies(undefined, 100)
       }
       await page.goto('/')
       if (isLocalhost) {
@@ -114,6 +116,7 @@ export const test = base.extend<Fixtures>({
         await auth.stubSignIn()
         // Keep this as a low-priority default to avoid missing-stub failures.
         await prisonApi.stubGetCaseLoads('HMI', 100)
+        await managingPrisonerAppsApi.stubGetActiveAgencies(undefined, 100)
       }
       await page.goto('/')
       if (isLocalhost) {

--- a/integration_tests/mockApis/managingPrisonerApps.ts
+++ b/integration_tests/mockApis/managingPrisonerApps.ts
@@ -135,8 +135,12 @@ export default {
       },
     })
   },
-  stubGetActiveAgencies: (): SuperAgentRequest => {
+  stubGetActiveAgencies: (
+    activeAgencies = ['HMI', 'PEI', 'HEI', 'BLI', 'MDI', 'CKI', 'LEI'],
+    priority = 5,
+  ): SuperAgentRequest => {
     return stubFor({
+      priority,
       request: {
         method: 'GET',
         url: '/managingPrisonerApps/v1/establishments',
@@ -144,7 +148,7 @@ export default {
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: ['HEI', 'BLI'],
+        jsonBody: activeAgencies,
       },
     })
   },

--- a/integration_tests/specs/view-applicationTestUtils.ts
+++ b/integration_tests/specs/view-applicationTestUtils.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test'
 import auth from '../mockApis/auth'
 import managingPrisonerAppsApi from '../mockApis/managingPrisonerApps'
 import documentManagement from '../mockApis/documentManagement'
+import personalRelationships from '../mockApis/personalRelationships'
 import prisonApi from '../mockApis/prison'
 import { resetStubs } from '../mockApis/wiremock'
 import { app, appWithPhotos } from '../../server/testData'
@@ -39,6 +40,9 @@ export async function visitApplicationPage({
     await resetStubs()
     await auth.stubSignIn()
     await prisonApi.stubGetCaseLoads()
+    await prisonApi.stubGetPrisonerByPrisonerNumber('A1234AA')
+    await personalRelationships.stubGetRelationships('OFFICIAL_RELATIONSHIP')
+    await personalRelationships.stubGetRelationships('SOCIAL_RELATIONSHIP')
     await managingPrisonerAppsApi.stubGetGroupsAndTypes()
     await managingPrisonerAppsApi.stubGetPrisonerApp({ app: application })
     await Promise.all(

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,6 +9,7 @@ import { appInsightsMiddleware } from './utils/azureAppInsights'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
 
 import setUpAuthentication from './middleware/setUpAuthentication'
+import checkActiveAgencyAccess from './middleware/checkActiveAgencyAccess'
 import setUpCsrf from './middleware/setUpCsrf'
 import setUpCurrentUser from './middleware/setUpCurrentUser'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
@@ -42,6 +43,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware(['ROLE_PRISON']))
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services.prisonService))
+  app.use(checkActiveAgencyAccess(services.managingPrisonerAppsService))
 
   app.get(
     '*splat',

--- a/server/middleware/checkActiveAgencyAccess.test.ts
+++ b/server/middleware/checkActiveAgencyAccess.test.ts
@@ -1,0 +1,70 @@
+import type { Request, Response } from 'express'
+import checkActiveAgencyAccess from './checkActiveAgencyAccess'
+import ManagingPrisonerAppsService from '../services/managingPrisonerAppsService'
+import config from '../config'
+
+describe('checkActiveAgencyAccess', () => {
+  const req: Request = {} as jest.Mocked<Request>
+  const next = jest.fn()
+
+  const managingPrisonerAppsService = {
+    getActiveAgencies: jest.fn(),
+  } as unknown as jest.Mocked<ManagingPrisonerAppsService>
+
+  function createRes(activeCaseLoadId?: string): Response {
+    return {
+      locals: {
+        user: {
+          username: 'USER1',
+          activeCaseLoadId,
+        },
+      },
+      status: jest.fn().mockReturnThis(),
+      render: jest.fn(),
+    } as unknown as Response
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('allows access when active caseload matches active agencies', async () => {
+    const res = createRes('CKI')
+    managingPrisonerAppsService.getActiveAgencies.mockResolvedValue(['MDI', 'CKI'])
+
+    const middleware = checkActiveAgencyAccess(managingPrisonerAppsService)
+    await middleware(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.render).not.toHaveBeenCalled()
+  })
+
+  it('allows access when active caseload is ***', async () => {
+    const res = createRes('***')
+    managingPrisonerAppsService.getActiveAgencies.mockResolvedValue(['MDI'])
+
+    const middleware = checkActiveAgencyAccess(managingPrisonerAppsService)
+    await middleware(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.render).not.toHaveBeenCalled()
+  })
+
+  it('renders standard error page when active caseload does not match', async () => {
+    const res = createRes('LEI')
+    managingPrisonerAppsService.getActiveAgencies.mockResolvedValue(['MDI', 'CKI'])
+
+    const middleware = checkActiveAgencyAccess(managingPrisonerAppsService)
+    await middleware(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(res.render).toHaveBeenCalledWith('pages/error', {
+      message: 'Something went wrong. The error has been logged. Please try again',
+      action: {
+        text: 'Select a different service',
+        href: config.apis.hmppsAuth.externalUrl,
+      },
+    })
+  })
+})

--- a/server/middleware/checkActiveAgencyAccess.test.ts
+++ b/server/middleware/checkActiveAgencyAccess.test.ts
@@ -11,13 +11,17 @@ describe('checkActiveAgencyAccess', () => {
     getActiveAgencies: jest.fn(),
   } as unknown as jest.Mocked<ManagingPrisonerAppsService>
 
-  function createRes(activeCaseLoadId?: string): Response {
+  function createRes(activeCaseLoadId?: string, includeUser = true): Response {
     return {
       locals: {
-        user: {
-          username: 'USER1',
-          activeCaseLoadId,
-        },
+        ...(includeUser
+          ? {
+              user: {
+                username: 'USER1',
+                activeCaseLoadId,
+              },
+            }
+          : {}),
       },
       status: jest.fn().mockReturnThis(),
       render: jest.fn(),
@@ -58,6 +62,24 @@ describe('checkActiveAgencyAccess', () => {
     await middleware(req, res, next)
 
     expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(res.render).toHaveBeenCalledWith('pages/error', {
+      message: 'Something went wrong. The error has been logged. Please try again',
+      action: {
+        text: 'Select a different service',
+        href: config.apis.hmppsAuth.externalUrl,
+      },
+    })
+  })
+
+  it('renders standard error page when user is missing', async () => {
+    const res = createRes(undefined, false)
+
+    const middleware = checkActiveAgencyAccess(managingPrisonerAppsService)
+    await middleware(req, res, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(managingPrisonerAppsService.getActiveAgencies).not.toHaveBeenCalled()
     expect(res.status).toHaveBeenCalledWith(403)
     expect(res.render).toHaveBeenCalledWith('pages/error', {
       message: 'Something went wrong. The error has been logged. Please try again',

--- a/server/middleware/checkActiveAgencyAccess.ts
+++ b/server/middleware/checkActiveAgencyAccess.ts
@@ -5,21 +5,32 @@ import ManagingPrisonerAppsService from '../services/managingPrisonerAppsService
 import { PrisonUser } from '../interfaces/hmppsUser'
 
 const ALL_CASELOADS = '***'
+const NO_ACTIVE_CASELOAD = '-no-active-case-load-id-'
+const STANDARD_ERROR_MESSAGE = 'Something went wrong. The error has been logged. Please try again'
+const ENTRY_DENIED_ERROR_PAGE = {
+  message: STANDARD_ERROR_MESSAGE,
+  action: {
+    text: 'Select a different service',
+    href: config.apis.hmppsAuth.externalUrl,
+  },
+}
 
 export default function checkActiveAgencyAccess(
   managingPrisonerAppsService: ManagingPrisonerAppsService,
 ): RequestHandler {
   return async (_req, res, next) => {
     const user = res.locals.user as PrisonUser | undefined
-    const activeCaseLoadId = user?.activeCaseLoadId
+
+    if (!user) {
+      logger.warn('Access denied as user is missing')
+      return res.status(403).render('pages/error', ENTRY_DENIED_ERROR_PAGE)
+    }
+
+    const activeCaseLoadId = user.activeCaseLoadId || NO_ACTIVE_CASELOAD
 
     try {
       const activeAgencies = await managingPrisonerAppsService.getActiveAgencies()
-      const isAllowed =
-        activeCaseLoadId === ALL_CASELOADS ||
-        (typeof activeCaseLoadId === 'string' &&
-          Array.isArray(activeAgencies) &&
-          activeAgencies.includes(activeCaseLoadId))
+      const isAllowed = activeCaseLoadId === ALL_CASELOADS || activeAgencies.includes(activeCaseLoadId)
 
       logger.info(
         `Active agency access check: activeCaseLoadId=${activeCaseLoadId}, activeAgencies=${JSON.stringify(activeAgencies)}, isAllowed=${isAllowed}`,
@@ -30,19 +41,13 @@ export default function checkActiveAgencyAccess(
       }
 
       logger.warn(
-        `Access denied for user ${user?.username}. activeCaseLoadId=${activeCaseLoadId}, activeAgencies=${JSON.stringify(activeAgencies)}`,
+        `Access denied for user ${user.username}. activeCaseLoadId=${activeCaseLoadId}, activeAgencies=${JSON.stringify(activeAgencies)}`,
       )
-      return res.status(403).render('pages/error', {
-        message: 'Something went wrong. The error has been logged. Please try again',
-        action: {
-          text: 'Select a different service',
-          href: config.apis.hmppsAuth.externalUrl,
-        },
-      })
+      return res.status(403).render('pages/error', ENTRY_DENIED_ERROR_PAGE)
     } catch (error) {
       logger.error('Unable to verify active agency access', error)
       return res.status(503).render('pages/error', {
-        message: 'Something went wrong. The error has been logged. Please try again',
+        message: STANDARD_ERROR_MESSAGE,
       })
     }
   }

--- a/server/middleware/checkActiveAgencyAccess.ts
+++ b/server/middleware/checkActiveAgencyAccess.ts
@@ -1,0 +1,49 @@
+import type { RequestHandler } from 'express'
+import logger from '../../logger'
+import config from '../config'
+import ManagingPrisonerAppsService from '../services/managingPrisonerAppsService'
+import { PrisonUser } from '../interfaces/hmppsUser'
+
+const ALL_CASELOADS = '***'
+
+export default function checkActiveAgencyAccess(
+  managingPrisonerAppsService: ManagingPrisonerAppsService,
+): RequestHandler {
+  return async (_req, res, next) => {
+    const user = res.locals.user as PrisonUser | undefined
+    const activeCaseLoadId = user?.activeCaseLoadId
+
+    try {
+      const activeAgencies = await managingPrisonerAppsService.getActiveAgencies()
+      const isAllowed =
+        activeCaseLoadId === ALL_CASELOADS ||
+        (typeof activeCaseLoadId === 'string' &&
+          Array.isArray(activeAgencies) &&
+          activeAgencies.includes(activeCaseLoadId))
+
+      logger.info(
+        `Active agency access check: activeCaseLoadId=${activeCaseLoadId}, activeAgencies=${JSON.stringify(activeAgencies)}, isAllowed=${isAllowed}`,
+      )
+
+      if (isAllowed) {
+        return next()
+      }
+
+      logger.warn(
+        `Access denied for user ${user?.username}. activeCaseLoadId=${activeCaseLoadId}, activeAgencies=${JSON.stringify(activeAgencies)}`,
+      )
+      return res.status(403).render('pages/error', {
+        message: 'Something went wrong. The error has been logged. Please try again',
+        action: {
+          text: 'Select a different service',
+          href: config.apis.hmppsAuth.externalUrl,
+        },
+      })
+    } catch (error) {
+      logger.error('Unable to verify active agency access', error)
+      return res.status(503).render('pages/error', {
+        message: 'Something went wrong. The error has been logged. Please try again',
+      })
+    }
+  }
+}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -5,6 +5,7 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
+{% set action = action or { text: "Go back to home page", href: "/" } %}
 
   <div class="govuk-body govuk-width-container govuk-!-padding-top-5 govuk-!-padding-bottom-5">
     <p class="govuk-heading-l">
@@ -12,8 +13,8 @@
     </p>
 
     {{ govukButton({
-      text: "Go back to home page",
-      href: "/"
+      text: action.text,
+      href: action.href
     }) }}
 
     {% if stack %}


### PR DESCRIPTION
This PR contains, 
https://dsdmoj.atlassian.net/browse/RA-1140

Added a middleware for the manage apps entry to validate the user's active caseload against active agencies.
If access is denied, the error page shows a configurable action button with text and link (followed the same button text and link used in another service)