### PR TITLE
RA-1163 | add stubs for application history messages and responses in tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,9 @@
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
 
 export default hmppsConfig({
-  extraIgnorePaths: ['integration_tests/Cypress (deprecated)/**', 'integration_tests/playwright_tests/reports/**'],
+  extraIgnorePaths: [
+    'integration_tests/Cypress (deprecated)/**',
+    'integration_tests/playwright_tests/reports/**',
+    'server/@types/prison-api.d.ts',
+  ],
 })

--- a/integration_tests/specs/application-history.spec.ts
+++ b/integration_tests/specs/application-history.spec.ts
@@ -4,7 +4,7 @@ import ApplicationHistoryPage from '../pages/applicationHistoryPage'
 import auth from '../mockApis/auth'
 import managingPrisonerAppsApi from '../mockApis/managingPrisonerApps'
 import prisonApi from '../mockApis/prison'
-import { resetStubs } from '../mockApis/wiremock'
+import { resetStubs, stubFor } from '../mockApis/wiremock'
 
 const targetBaseUrl = process.env.PW_BASE_URL || process.env.DPS_PRISONER_URL || 'http://localhost:3007'
 const isWiremock = process.env.PW_ENV === 'mock' || targetBaseUrl.includes('localhost')
@@ -49,5 +49,140 @@ test.describe('Application History Page', () => {
   test('should display the history page content', async ({ page }) => {
     const historyPage = new ApplicationHistoryPage(page)
     await expect(historyPage.historyContent()).toBeVisible()
+  })
+})
+
+test.describe('Application History Page message rendering', () => {
+  const commentId = 'history-comment-id'
+  const responseId = 'history-response-id'
+
+  test.beforeEach(async ({ page, signIn }) => {
+    test.skip(!isWiremock, 'Custom WireMock stubs are required for this scenario')
+
+    await resetStubs()
+    await auth.stubSignIn()
+    await prisonApi.stubGetCaseLoads()
+    await managingPrisonerAppsApi.stubGetPrisonerApp({ app })
+    await managingPrisonerAppsApi.stubGetGroupsAndTypes()
+
+    await stubFor({
+      request: {
+        method: 'GET',
+        url: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/history`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: [
+          {
+            id: 'history-item-assigned',
+            appId: app.id,
+            entityId: 'assigned-group-id',
+            entityType: 'ASSIGNED_GROUP',
+            activityMessage: {
+              header: 'Assigned to central team',
+              body: 'Assigned to group',
+            },
+            createdDate: '2026-07-10T10:00:00.000Z',
+          },
+          {
+            id: 'history-item-comment',
+            appId: app.id,
+            entityId: commentId,
+            entityType: 'COMMENT',
+            activityMessage: {
+              header: 'Staff comment added',
+            },
+            createdDate: '2026-07-10T10:01:00.000Z',
+          },
+          {
+            id: 'history-item-response',
+            appId: app.id,
+            entityId: responseId,
+            entityType: 'RESPONSE',
+            activityMessage: {
+              header: 'Decision recorded',
+            },
+            createdDate: '2026-07-10T10:02:00.000Z',
+          },
+        ],
+      },
+    })
+
+    await stubFor({
+      request: {
+        method: 'GET',
+        url: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/comments?page=1&size=20&createdBy=true`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          page: 1,
+          totalElements: 1,
+          exhausted: true,
+          contents: [
+            {
+              id: commentId,
+              appId: app.id,
+              message: 'History comment is visible',
+              prisonerNumber: app.requestedBy.username,
+              createdDate: '2026-07-10T10:01:10.000Z',
+              visibility: 'STAFF_ONLY',
+              createdByType: 'STAFF',
+              createdBy: {
+                username: 'TEST_GEN',
+                userId: '487900',
+                fullName: 'Staff Name',
+                category: 'STAFF',
+                establishment: {
+                  id: 'TEST_ESTABLISHMENT_FIRST',
+                  name: 'ESTABLISHMENT_NAME_1',
+                },
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    await stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/responses/${responseId}.*`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          id: responseId,
+          prisonerId: app.requestedBy.username,
+          appId: app.id,
+          decision: 'DECLINED',
+          reason: 'Response reason is visible',
+          createdDate: '2026-07-10T10:02:10.000Z',
+          appliesTo: [],
+          createdBy: {
+            username: 'TEST_GEN',
+            userId: '487900',
+            fullName: 'Staff Name',
+            category: 'STAFF',
+            establishment: {
+              id: 'TEST_ESTABLISHMENT_FIRST',
+              name: 'ESTABLISHMENT_NAME_1',
+            },
+          },
+        },
+      },
+    })
+
+    await signIn()
+    await page.goto(`/applications/${app.requestedBy.username}/${app.id}/history`)
+  })
+
+  test('should display comment and response messages when history items reference them', async ({ page }) => {
+    await expect(page.getByText('History comment is visible')).toBeVisible()
+    await expect(page.getByText('Response reason is visible')).toBeVisible()
+    await expect(page.getByText('Assigned to group')).toBeVisible()
   })
 })

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -26226,14 +26226,7 @@ export interface operations {
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
         sort?:
-          | 'alertId'
-          | 'bookingId'
-          | 'alertType'
-          | 'alertCode'
-          | 'comment'
-          | 'dateCreated'
-          | 'dateExpires'
-          | 'active'
+          'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
         /**
          * @description Sort order
          * @example DESC

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -26226,7 +26226,14 @@ export interface operations {
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
         sort?:
-          'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
+          | 'alertId'
+          | 'bookingId'
+          | 'alertType'
+          | 'alertCode'
+          | 'comment'
+          | 'dateCreated'
+          | 'dateExpires'
+          | 'active'
         /**
          * @description Sort order
          * @example DESC

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -25934,18 +25934,7 @@ export interface operations {
          * @description participationRoles
          * @example ASSIAL
          */
-        participationRoles:
-          | 'ACTINV'
-          | 'ASSIAL'
-          | 'FIGHT'
-          | 'IMPED'
-          | 'PERP'
-          | 'SUSASS'
-          | 'SUSINV'
-          | 'VICT'
-          | 'AI'
-          | 'PAS'
-          | 'AO'
+        participationRoles: 'ACTINV' | 'ASSIAL' | 'FIGHT' | 'IMPED' | 'PERP' | 'SUSASS' | 'SUSINV' | 'VICT' | 'AI' | 'PAS' | 'AO'
       }
       header?: never
       path: {
@@ -26225,15 +26214,7 @@ export interface operations {
          */
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
-        sort?:
-          | 'alertId'
-          | 'bookingId'
-          | 'alertType'
-          | 'alertCode'
-          | 'comment'
-          | 'dateCreated'
-          | 'dateExpires'
-          | 'active'
+        sort?: 'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
         /**
          * @description Sort order
          * @example DESC
@@ -26392,15 +26373,7 @@ export interface operations {
          */
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
-        sort?:
-          | 'alertId'
-          | 'bookingId'
-          | 'alertType'
-          | 'alertCode'
-          | 'comment'
-          | 'dateCreated'
-          | 'dateExpires'
-          | 'active'
+        sort?: 'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
         /**
          * @description Sort order
          * @example DESC

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -25935,7 +25935,17 @@ export interface operations {
          * @example ASSIAL
          */
         participationRoles:
-          'ACTINV' | 'ASSIAL' | 'FIGHT' | 'IMPED' | 'PERP' | 'SUSASS' | 'SUSINV' | 'VICT' | 'AI' | 'PAS' | 'AO'
+          | 'ACTINV'
+          | 'ASSIAL'
+          | 'FIGHT'
+          | 'IMPED'
+          | 'PERP'
+          | 'SUSASS'
+          | 'SUSINV'
+          | 'VICT'
+          | 'AI'
+          | 'PAS'
+          | 'AO'
       }
       header?: never
       path: {
@@ -26216,7 +26226,14 @@ export interface operations {
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
         sort?:
-          'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
+          | 'alertId'
+          | 'bookingId'
+          | 'alertType'
+          | 'alertCode'
+          | 'comment'
+          | 'dateCreated'
+          | 'dateExpires'
+          | 'active'
         /**
          * @description Sort order
          * @example DESC
@@ -26376,7 +26393,14 @@ export interface operations {
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
         sort?:
-          'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
+          | 'alertId'
+          | 'bookingId'
+          | 'alertType'
+          | 'alertCode'
+          | 'comment'
+          | 'dateCreated'
+          | 'dateExpires'
+          | 'active'
         /**
          * @description Sort order
          * @example DESC

--- a/server/@types/prison-api.d.ts
+++ b/server/@types/prison-api.d.ts
@@ -25934,7 +25934,18 @@ export interface operations {
          * @description participationRoles
          * @example ASSIAL
          */
-        participationRoles: 'ACTINV' | 'ASSIAL' | 'FIGHT' | 'IMPED' | 'PERP' | 'SUSASS' | 'SUSINV' | 'VICT' | 'AI' | 'PAS' | 'AO'
+        participationRoles:
+          | 'ACTINV'
+          | 'ASSIAL'
+          | 'FIGHT'
+          | 'IMPED'
+          | 'PERP'
+          | 'SUSASS'
+          | 'SUSINV'
+          | 'VICT'
+          | 'AI'
+          | 'PAS'
+          | 'AO'
       }
       header?: never
       path: {
@@ -26214,7 +26225,15 @@ export interface operations {
          */
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
-        sort?: 'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
+        sort?:
+          | 'alertId'
+          | 'bookingId'
+          | 'alertType'
+          | 'alertCode'
+          | 'comment'
+          | 'dateCreated'
+          | 'dateExpires'
+          | 'active'
         /**
          * @description Sort order
          * @example DESC
@@ -26373,7 +26392,15 @@ export interface operations {
          */
         alertCodes?: string
         /** @description Comma separated list of one or more Alert fields */
-        sort?: 'alertId' | 'bookingId' | 'alertType' | 'alertCode' | 'comment' | 'dateCreated' | 'dateExpires' | 'active'
+        sort?:
+          | 'alertId'
+          | 'bookingId'
+          | 'alertType'
+          | 'alertCode'
+          | 'comment'
+          | 'dateCreated'
+          | 'dateExpires'
+          | 'active'
         /**
          * @description Sort order
          * @example DESC


### PR DESCRIPTION
- e2e coverage for history tab for applications
- Prison-api was a lint fix change

History tab for applications 

<img width="1723" height="1023" alt="Screenshot 2026-07-10 at 14 21 52" src="https://github.com/user-attachments/assets/af404b4b-8e79-4ebd-ae1b-e46f74074ecc" />
