### PR TITLE
RA-1167 | e2e test coverage for staff and staff to prisoner messaging function

### DIFF
--- a/integration_tests/specs/action-and-reply.spec.ts
+++ b/integration_tests/specs/action-and-reply.spec.ts
@@ -59,6 +59,26 @@ Object.values(appTypes).forEach(({ id, name }) => {
       await expect(actionAndReplyPage.errorSummary()).toContainText('Add a reason')
     })
 
+    test('should allow navigating to Messages from Action and reply', async ({ page }) => {
+      if (isWiremock) {
+        await managingPrisonerAppsApi.stubGetComments({ app: pendingApplication })
+      }
+
+      const messagesTab = page.locator('.moj-sub-navigation__link:has-text("Messages")')
+      await expect(messagesTab).toHaveAttribute(
+        'href',
+        `/applications/${pendingApplication.requestedBy.username}/${pendingApplication.id}/comments`,
+      )
+
+      await messagesTab.click()
+
+      await expect(page).toHaveURL(
+        new RegExp(`/applications/${pendingApplication.requestedBy.username}/${pendingApplication.id}/comments`),
+      )
+      await expect(page.getByRole('heading', { name: 'Messages and replies' })).toBeVisible()
+      await expect(page.locator('.moj-sub-navigation__item a[aria-current="page"]')).toContainText('Messages')
+    })
+
     test('should successfully submit with APPROVED decision', async ({ page }) => {
       if (isWiremock) {
         await managingPrisonerAppsApi.stubAddAppResponse({ app: pendingApplication, decision: 'APPROVED' })

--- a/integration_tests/specs/comments.spec.ts
+++ b/integration_tests/specs/comments.spec.ts
@@ -5,10 +5,87 @@ import CommentsPage from '../pages/commentsPage'
 import auth from '../mockApis/auth'
 import managingPrisonerAppsApi from '../mockApis/managingPrisonerApps'
 import prisonApi from '../mockApis/prison'
-import { resetStubs } from '../mockApis/wiremock'
+import { resetStubs, stubFor } from '../mockApis/wiremock'
 
 const targetBaseUrl = process.env.PW_BASE_URL || process.env.DPS_PRISONER_URL || 'http://localhost:3007'
 const isWiremock = process.env.PW_ENV === 'mock' || targetBaseUrl.includes('localhost')
+
+const stubCommentSubmissionWithVisibility = async ({
+  message,
+  visibility,
+}: {
+  message: string
+  visibility: 'STAFF_ONLY' | 'STAFF_AND_PRISONER'
+}) => {
+  await stubFor({
+    priority: 1,
+    request: {
+      method: 'POST',
+      url: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/comments`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        id: 'comment-id-1',
+        appId: app.id,
+        message,
+        prisonerNumber: app.requestedBy.username,
+        createdDate: '2025-04-09T15:57:29Z',
+        visibility,
+        createdByType: 'STAFF',
+        createdBy: {
+          username: 'TEST_GEN',
+          userId: '487900',
+          fullName: 'Staff Name',
+          category: 'STAFF',
+          establishment: {
+            id: 'TEST_ESTABLISHMENT_FIRST',
+            name: 'ESTABLISHMENT_NAME_1',
+          },
+        },
+      },
+    },
+  })
+
+  await stubFor({
+    priority: 1,
+    request: {
+      method: 'GET',
+      url: `/managingPrisonerApps/v1/prisoners/${app.requestedBy.username}/apps/${app.id}/comments?page=1&size=20&createdBy=true`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        page: 1,
+        totalElements: 1,
+        exhausted: true,
+        contents: [
+          {
+            id: 'comment-id-1',
+            appId: app.id,
+            message,
+            prisonerNumber: app.requestedBy.username,
+            createdDate: '2025-04-09T15:57:29Z',
+            visibility,
+            createdByType: 'STAFF',
+            createdBy: {
+              username: 'TEST_GEN',
+              userId: '487900',
+              fullName: 'Staff Name',
+              category: 'STAFF',
+              establishment: {
+                id: 'TEST_ESTABLISHMENT_FIRST',
+                name: 'ESTABLISHMENT_NAME_1',
+              },
+            },
+          },
+        ],
+      },
+    },
+  })
+}
 
 test.describe('Comments Page', () => {
   test.beforeEach(async ({ page, signIn }) => {
@@ -49,6 +126,20 @@ test.describe('Comments Page', () => {
     await expect(commentsPage.commentsSectionHeading()).toBeVisible()
   })
 
+  test('should allow navigating to Action and reply from Messages', async ({ page }) => {
+    if (isWiremock) {
+      await managingPrisonerAppsApi.stubGetAppResponse({ app, decision: undefined })
+    }
+
+    const actionAndReplyTab = page.locator('.moj-sub-navigation__link:has-text("Action and reply")')
+    await expect(actionAndReplyTab).toHaveAttribute('href', `/applications/${app.requestedBy.username}/${app.id}/reply`)
+
+    await actionAndReplyTab.click()
+
+    await expect(page).toHaveURL(`/applications/${app.requestedBy.username}/${app.id}/reply`)
+    await expect(page.getByRole('heading', { name: 'Action and reply' })).toBeVisible()
+  })
+
   test('should allow a user to add a comment and display it', async ({ page }) => {
     if (isWiremock) {
       await managingPrisonerAppsApi.stubAddComments({ app })
@@ -64,6 +155,46 @@ test.describe('Comments Page', () => {
     await expect(page.locator('.moj-message-item__text--sent', { hasText: 'This is my first comment' })).toBeVisible()
     await expect(page.getByText('Staff Name')).toBeVisible()
     await expect(page.getByText('9 April 2025')).toBeVisible()
+  })
+
+  test('should show staff only visibility when sending a staff-only message', async ({ page }) => {
+    if (isWiremock) {
+      await stubCommentSubmissionWithVisibility({
+        message: 'Staff only message',
+        visibility: 'STAFF_ONLY',
+      })
+    }
+
+    const commentsPage = new CommentsPage(page)
+    await commentsPage.commentBox().fill('Staff only message')
+    await page.getByRole('radio', { name: 'Staff only' }).check()
+    await commentsPage.submitButton().click()
+
+    await expect(page).toHaveURL(`/applications/${app.requestedBy.username}/${app.id}/comments`)
+    await expect(page.locator('.app-message-item--staff-only')).toBeVisible()
+    await expect(page.locator('.app-message-visibility--staff-only')).toContainText('Staff only')
+    await expect(page.locator('.moj-message-item__text--sent', { hasText: 'Staff only message' })).toBeVisible()
+  })
+
+  test('should show staff and prisoner visibility when sending a prisoner-and-staff message', async ({ page }) => {
+    if (isWiremock) {
+      await stubCommentSubmissionWithVisibility({
+        message: 'Shared with prisoner',
+        visibility: 'STAFF_AND_PRISONER',
+      })
+    }
+
+    const commentsPage = new CommentsPage(page)
+    await commentsPage.commentBox().fill('Shared with prisoner')
+    await page.getByRole('radio', { name: 'Prisoner and staff' }).check()
+    const confirmVisibilityButton = page.locator('#visibility-modal-confirm')
+    await expect(confirmVisibilityButton).toBeVisible()
+    await confirmVisibilityButton.click()
+
+    await expect(page).toHaveURL(`/applications/${app.requestedBy.username}/${app.id}/comments`)
+    await expect(page.locator('.app-message-item--prisoner-and-staff')).toBeVisible()
+    await expect(page.locator('.app-message-visibility--prisoner-and-staff')).toContainText('Staff and prisoner')
+    await expect(page.locator('.moj-message-item__text--sent', { hasText: 'Shared with prisoner' })).toBeVisible()
   })
 
   test('should show an error message when no comment is entered', async ({ page }) => {


### PR DESCRIPTION
- Add e2e test coverage for staff messaging and prisoner to staff messaging
- Navigation journeys to Messages tab from other tabbed pages

<img width="1920" height="1159" alt="Screenshot 2026-07-10 at 15 43 54" src="https://github.com/user-attachments/assets/99b75a7a-6d6a-46d3-a839-ffc216d7b615" />
<img width="1916" height="1156" alt="Screenshot 2026-07-10 at 15 43 43" src="https://github.com/user-attachments/assets/efb4fc30-4ce5-459b-8c99-c02339a0b8ae" />
<img width="1919" height="1151" alt="Screenshot 2026-07-10 at 15 43 34" src="https://github.com/user-attachments/assets/1503364f-15b0-4399-9aa4-86338675911e" />
