### PR TITLE
RA-1267-RA-1266: Enable log method page document camera feature

### DIFF
--- a/server/constants/enabledEstablishments.ts
+++ b/server/constants/enabledEstablishments.ts
@@ -1,4 +1,4 @@
-export const LOG_METHOD_ENABLED_ESTABLISHMENTS: ReadonlyArray<string> = ['HMI', 'LEI', 'LNI']
+export const LOG_METHOD_ENABLED_ESTABLISHMENTS: ReadonlyArray<string> = ['HMI', 'LEI', 'LNI', 'MDI', 'HHI']
 
 export const isLogMethodEnabledEstablishment = (activeCaseLoadId?: string): boolean =>
   Boolean(activeCaseLoadId && LOG_METHOD_ENABLED_ESTABLISHMENTS.includes(activeCaseLoadId))


### PR DESCRIPTION
Enable log method page for Moorland (MDI) and Holme House (HHI) establishments, thereby enabling Document camera feature.
**Only merge when it is time to put both establishments Document camera feature live!**
