### PR TITLE
RA-1350 | Parallel workers through playwright sharding 

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -150,6 +150,20 @@ jobs:
           path: |
             test_results/playwright/test-report/*
             test_results/playwright/junit.xml
+  node_integration_tests_required:
+    name: node integration tests required
+    needs: [node_integration_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix status
+        run: |
+          if [[ "${{ needs.node_integration_tests.result }}" == "success" ]]; then
+            exit 0
+          else
+            echo "node_integration_tests result: ${{ needs.node_integration_tests.result }}"
+            exit 1
+          fi
   node_integration_test_report:
     name: node integration test report
     needs: [node_integration_tests]
@@ -204,7 +218,7 @@ jobs:
     name: Build docker image from hmpps-github-actions
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
-      - node_integration_tests
+      - node_integration_tests_required
       - node_integration_test_report
       - node_unit_tests
     with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,23 +52,23 @@ jobs:
       matrix:
         include:
           - shard: 1
-            name: Playwright integration parallel worker (1)
+            name: Integration test parallel worker (1)
             app_port: 3007
             wiremock_port: 9091
           - shard: 2
-            name: Playwright integration parallel worker (2)
+            name: Integration test parallel worker (2)
             app_port: 3008
             wiremock_port: 9092
           - shard: 3
-            name: Playwright integration parallel worker (3)
+            name: Integration test parallel worker (3)
             app_port: 3009
             wiremock_port: 9093
           - shard: 4
-            name: Playwright integration parallel worker (4)
+            name: Integration test parallel worker (4)
             app_port: 3010
             wiremock_port: 9094
           - shard: 5
-            name: Playwright integration parallel worker (5)
+            name: Integration test parallel worker (5)
             app_port: 3011
             wiremock_port: 9095
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           name: integration-test-worker-${{ matrix.shard }}-test-report
           path: |
-            test_results/playwright/test-report
+            test_results/playwright/test-report/*
             test_results/playwright/junit.xml
   node_integration_test_report:
     name: node integration test report

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -151,7 +151,7 @@ jobs:
             test_results/playwright/test-report/*
             test_results/playwright/junit.xml
   ci_pass:
-    name: ci-pass
+    name: node integration tests / Run the integration tests
     needs: [node_integration_tests]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -46,9 +46,78 @@ jobs:
   # generic node integration tests using wiremock - feel free to override with local tests if required
   node_integration_tests:
     name: node integration tests
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_integration_tests.yml@v2 # WORKFLOW_VERSION
     needs: [node_build]
-    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 1
+            app_port: 3007
+            wiremock_port: 9091
+          - shard: 2
+            app_port: 3008
+            wiremock_port: 9092
+          - shard: 3
+            app_port: 3009
+            wiremock_port: 9093
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      wiremock:
+        image: wiremock/wiremock
+        ports:
+          - ${{ matrix.wiremock_port }}:8080
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm run int-test-init:ci
+
+      - name: Start application
+        env:
+          PORT: ${{ matrix.app_port }}
+          PW_BASE_URL: http://localhost:${{ matrix.app_port }}
+          HMPPS_AUTH_URL: http://localhost:${{ matrix.wiremock_port }}/auth
+          TOKEN_VERIFICATION_API_URL: http://localhost:${{ matrix.wiremock_port }}/verification
+          MANAGING_PRISONER_APPS_API_URL: http://localhost:${{ matrix.wiremock_port }}/managingPrisonerApps
+          PRISON_API_URL: http://localhost:${{ matrix.wiremock_port }}/prison
+          PERSONAL_RELATIONSHIPS_API_URL: http://localhost:${{ matrix.wiremock_port }}/personalRelationships
+          DOCUMENT_API_URL: http://localhost:${{ matrix.wiremock_port }}/documentApi
+          OS_PLACES_API_URL: http://localhost:${{ matrix.wiremock_port }}/osPlaces
+        run: nohup npm run start-feature > "$RUNNER_TEMP/start-feature.log" 2>&1 &
+
+      - name: Wait for application
+        env:
+          APP_PORT: ${{ matrix.app_port }}
+        run: |
+          for attempt in {1..60}; do
+            if curl --fail --silent "http://localhost:${APP_PORT}/health" > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "Application did not become ready"
+          cat "$RUNNER_TEMP/start-feature.log"
+          exit 1
+
+      - name: Run integration tests
+        env:
+          PW_ENV: mock
+          PW_BASE_URL: http://localhost:${{ matrix.app_port }}
+          WIREMOCK_PORT: ${{ matrix.wiremock_port }}
+        run: npm run int-test -- --shard=${{ matrix.shard }}/3
   helm_lint:
     strategy:
       matrix:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           name: integration-test-worker-${{ matrix.shard }}-test-report
           path: |
-            test_results/playwright/blob-report
+            test_results/playwright/test-report
             test_results/playwright/junit.xml
   node_integration_test_report:
     name: node integration test report
@@ -171,13 +171,14 @@ jobs:
         with:
           pattern: integration-test-worker-*-test-report
           path: all-test-reports
+          merge-multiple: true
 
       - name: Merge Playwright reports
         run: |
           mkdir -p test_results/playwright
           rm -rf test_results/playwright/report
           npx playwright merge-reports --reporter html ./all-test-reports
-          mv test_results/playwright/html-report test_results/playwright/report
+          mv playwright-report test_results/playwright/report
 
       - name: Upload consolidated report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -171,13 +171,19 @@ jobs:
         with:
           pattern: integration-test-worker-*-test-report
           path: all-test-reports
-          merge-multiple: true
 
       - name: Merge Playwright reports
         run: |
           mkdir -p test_results/playwright
+          mkdir -p merged-test-reports
           rm -rf test_results/playwright/report
-          npx playwright merge-reports --reporter html ./all-test-reports
+          find all-test-reports -type f -name '*.zip' -exec cp '{}' merged-test-reports/ '\;'
+          if ! find merged-test-reports -type f -name '*.zip' -print -quit | grep -q .; then
+            echo 'No Playwright blob report zip files found after download'
+            find all-test-reports -maxdepth 3 -type f -print
+            exit 1
+          fi
+          npx playwright merge-reports --reporter html ./merged-test-reports
           mv playwright-report test_results/playwright/report
 
       - name: Upload consolidated report

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,21 +45,32 @@ jobs:
     secrets: inherit
   # generic node integration tests using wiremock - feel free to override with local tests if required
   node_integration_tests:
-    name: node integration tests
+    name: ${{ matrix.name }}
     needs: [node_build]
     strategy:
       fail-fast: false
       matrix:
         include:
           - shard: 1
+            name: Playwright integration parallel worker (1)
             app_port: 3007
             wiremock_port: 9091
           - shard: 2
+            name: Playwright integration parallel worker (2)
             app_port: 3008
             wiremock_port: 9092
           - shard: 3
+            name: Playwright integration parallel worker (3)
             app_port: 3009
             wiremock_port: 9093
+          - shard: 4
+            name: Playwright integration parallel worker (4)
+            app_port: 3010
+            wiremock_port: 9094
+          - shard: 5
+            name: Playwright integration parallel worker (5)
+            app_port: 3011
+            wiremock_port: 9095
     runs-on: ubuntu-latest
     timeout-minutes: 60
     services:
@@ -129,7 +140,50 @@ jobs:
           PW_ENV: mock
           PW_BASE_URL: http://localhost:${{ matrix.app_port }}
           WIREMOCK_PORT: ${{ matrix.wiremock_port }}
-        run: npm run int-test -- --shard=${{ matrix.shard }}/3
+        run: npm run int-test -- --shard=${{ matrix.shard }}/5
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-worker-${{ matrix.shard }}-test-report
+          path: |
+            test_results/playwright/blob-report
+            test_results/playwright/junit.xml
+  node_integration_test_report:
+    name: node integration test report
+    needs: [node_integration_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download shard reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: integration-test-worker-*-test-report
+          path: all-test-reports
+
+      - name: Merge Playwright reports
+        run: |
+          mkdir -p test_results/playwright
+          rm -rf test_results/playwright/report
+          npx playwright merge-reports --reporter html ./all-test-reports
+          mv test_results/playwright/html-report test_results/playwright/report
+
+      - name: Upload consolidated report
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-report
+          path: test_results/playwright/report
   helm_lint:
     strategy:
       matrix:
@@ -144,6 +198,7 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
       - node_integration_tests
+      - node_integration_test_report
       - node_unit_tests
     with:
       docker_registry: 'ghcr.io'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -84,6 +84,18 @@ jobs:
       - name: Install Playwright browsers
         run: npm run int-test-init:ci
 
+      - name: Seed WireMock health stubs
+        env:
+          WIREMOCK_PORT: ${{ matrix.wiremock_port }}
+        run: |
+          curl --fail --silent -X POST "http://localhost:${WIREMOCK_PORT}/__admin/mappings" \
+            -H 'Content-Type: application/json' \
+            -d '{"request":{"method":"GET","urlPattern":"/auth/health/ping"},"response":{"status":200}}'
+
+          curl --fail --silent -X POST "http://localhost:${WIREMOCK_PORT}/__admin/mappings" \
+            -H 'Content-Type: application/json' \
+            -d '{"request":{"method":"GET","urlPattern":"/(verification/)?health/ping"},"response":{"status":200,"headers":{"Content-Type":"application/json;charset=UTF-8"},"jsonBody":{"status":"UP"}}}'
+
       - name: Start application
         env:
           PORT: ${{ matrix.app_port }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -177,7 +177,7 @@ jobs:
           mkdir -p test_results/playwright
           mkdir -p merged-test-reports
           rm -rf test_results/playwright/report
-          find all-test-reports -type f -name '*.zip' -exec cp '{}' merged-test-reports/ '\;'
+          find all-test-reports -type f -name '*.zip' -print0 | xargs -0 -I '{}' cp '{}' merged-test-reports/
           if ! find merged-test-reports -type f -name '*.zip' -print -quit | grep -q .; then
             echo 'No Playwright blob report zip files found after download'
             find all-test-reports -maxdepth 3 -type f -print

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -150,8 +150,8 @@ jobs:
           path: |
             test_results/playwright/test-report/*
             test_results/playwright/junit.xml
-  node_integration_tests_required:
-    name: node integration tests required
+  ci_pass:
+    name: ci-pass
     needs: [node_integration_tests]
     if: always()
     runs-on: ubuntu-latest
@@ -218,7 +218,7 @@ jobs:
     name: Build docker image from hmpps-github-actions
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
-      - node_integration_tests_required
+      - ci_pass
       - node_integration_test_report
       - node_unit_tests
     with:

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -1,14 +1,16 @@
 import superagent, { SuperAgentRequest, Response } from 'superagent'
 
-const url = 'http://localhost:9091/__admin'
+const defaultWiremockPort = '9091'
+
+const getWiremockUrl = () => `http://localhost:${process.env.WIREMOCK_PORT || defaultWiremockPort}/__admin`
 
 const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
-  superagent.post(`${url}/mappings`).send(mapping)
+  superagent.post(`${getWiremockUrl()}/mappings`).send(mapping)
 
 const getMatchingRequests = (body: string | Record<string, unknown> | object): SuperAgentRequest =>
-  superagent.post(`${url}/requests/find`).send(body)
+  superagent.post(`${getWiremockUrl()}/requests/find`).send(body)
 
 const resetStubs = (): Promise<Array<Response>> =>
-  Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
+  Promise.all([superagent.delete(`${getWiremockUrl()}/mappings`), superagent.delete(`${getWiremockUrl()}/requests`)])
 
 export { stubFor, getMatchingRequests, resetStubs }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   globalTimeout: 60 * 60 * 1000,
   /* Run tests in files in parallel */
   fullyParallel: false,
-  /* Ensure tests run consecutively due to inability to share wiremock instance */
+  /* Keep each Playwright process serial; CI parallelism is handled by job sharding. */
   workers: 1,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,11 +29,17 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [
-    ['list'],
-    ['html', { outputFolder: 'test_results/playwright/report', open: process.env.CI ? 'never' : 'on-failure' }],
-    ['junit', { outputFile: 'test_results/playwright/junit.xml' }],
-  ],
+  reporter: process.env.CI
+    ? [
+        ['list'],
+        ['blob', { outputDir: 'test_results/playwright/test-report' }],
+        ['junit', { outputFile: 'test_results/playwright/junit.xml' }],
+      ]
+    : [
+        ['list'],
+        ['html', { outputFolder: 'test_results/playwright/report', open: 'on-failure' }],
+        ['junit', { outputFile: 'test_results/playwright/junit.xml' }],
+      ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     actionTimeout: 30 /* seconds */ * 1000,


### PR DESCRIPTION
Configure sharding for paralell workers (5)

I've sharded the tests into 5 parallel workers which now runs the integration tests across 5 workers on the pipeline jobs
```

  node_integration_tests:
    name: ${{ matrix.name }}
    needs: [node_build]
    strategy:
      fail-fast: false
      matrix:
        include:
          - shard: 1
            name: Playwright integration parallel worker (1)
            app_port: 3007
            wiremock_port: 9091
          - shard: 2
            name: Playwright integration parallel worker (2)
            app_port: 3008
            wiremock_port: 9092
          - shard: 3
            name: Playwright integration parallel worker (3)
            app_port: 3009
            wiremock_port: 9093
          - shard: 4
            name: Playwright integration parallel worker (4)
            app_port: 3010
            wiremock_port: 9094
          - shard: 5
            name: Playwright integration parallel worker (5)
            app_port: 3011
            wiremock_port: 9095
```

Pipeline now takes 4mins to run all the e2e tests 