### PR TITLE
RA-1341 | RA-1345

### DIFF
--- a/integration_tests/pages/printReplyPage.ts
+++ b/integration_tests/pages/printReplyPage.ts
@@ -22,6 +22,10 @@ export default class PrintReplyPage extends AbstractPage {
     return this.page.locator('.govuk-summary-list').first()
   }
 
+  printableTemplate(): PageElement {
+    return this.page.locator('div[class*="govuk-!-display-block-print"]')
+  }
+
   async checkOnPage(): Promise<void> {
     await expect(this.activeTab()).toContainText('Print reply')
   }

--- a/integration_tests/specs/forward-application.spec.ts
+++ b/integration_tests/specs/forward-application.spec.ts
@@ -83,6 +83,29 @@ test.describe('Forward Application Page', () => {
     await expect(page.getByText(`Application forwarded to ${deptLabel.trim()}`)).toBeVisible()
   })
 
+  test('should forward application to a new department', async ({ page }) => {
+    const forwardPage = new ForwardApplicationPage(page)
+
+    if (isWiremock) {
+      await managingPrisonerAppsApi.stubForwardApp({ applicationId: app.id })
+    }
+
+    const departments = forwardPage.departmentRadios()
+    await expect(departments).toHaveCount(2)
+
+    const secondDepartment = departments.nth(1)
+    const secondDepartmentId = await secondDepartment.getAttribute('id')
+    const secondDepartmentValue = await secondDepartment.getAttribute('value')
+    const secondDepartmentLabel = await page.locator(`label[for="${secondDepartmentId}"]`).innerText()
+
+    await forwardPage.selectDepartment(secondDepartmentValue)
+    await forwardPage.enterForwardingReason('Forwarding to a new department for follow-up')
+    await forwardPage.submit()
+
+    await expect(page).toHaveURL(new RegExp(`/applications/${app.requestedBy.username}/${app.id}`))
+    await expect(page.getByText(`Application forwarded to ${secondDepartmentLabel.trim()}`)).toBeVisible()
+  })
+
   test('should show validation error when forwarding reason exceeds 1000 characters', async ({ page }) => {
     const forwardPage = new ForwardApplicationPage(page)
     const longReason = 'a'.repeat(1001)

--- a/integration_tests/specs/print-reply.spec.ts
+++ b/integration_tests/specs/print-reply.spec.ts
@@ -60,9 +60,9 @@ test.describe('Print reply tab', () => {
 
     await page.evaluate(() => {
       // Track print invocation from the page script click handler.
-      ;(window as Window & { __printInvoked?: boolean }).__printInvoked = false
+      ;(window as Window & { printInvokedForTest?: boolean }).printInvokedForTest = false
       window.print = () => {
-        ;(window as Window & { __printInvoked?: boolean }).__printInvoked = true
+        ;(window as Window & { printInvokedForTest?: boolean }).printInvokedForTest = true
       }
     })
 
@@ -70,7 +70,7 @@ test.describe('Print reply tab', () => {
 
     await expect
       .poll(async () =>
-        page.evaluate(() => (window as Window & { __printInvoked?: boolean }).__printInvoked === true),
+        page.evaluate(() => (window as Window & { printInvokedForTest?: boolean }).printInvokedForTest === true),
       )
       .toBe(true)
   })

--- a/integration_tests/specs/print-reply.spec.ts
+++ b/integration_tests/specs/print-reply.spec.ts
@@ -43,4 +43,64 @@ test.describe('Print reply tab', () => {
     await expect(printReplyPage.summaryList()).toContainText('Location')
     await expect(printReplyPage.printButton()).toBeVisible()
   })
+
+  test('should trigger browser print when selecting Print reply for a closed application', async ({ page, signIn }) => {
+    test.skip(!isWiremock, 'Requires WireMock stubs')
+
+    const closedApplication = { ...app, status: APPLICATION_STATUS.APPROVED }
+    await visitApplicationPage({ page, signIn, application: closedApplication })
+    await managingPrisonerAppsApi.stubGetAppResponse({ app: closedApplication, decision: 'APPROVED' })
+
+    const viewApplicationPage = new ViewApplicationPage(page)
+    await viewApplicationPage.printReplyTab().click()
+
+    const printReplyPage = new PrintReplyPage(page)
+    await printReplyPage.checkOnPage()
+    await expect(printReplyPage.printButton()).toBeVisible()
+
+    await page.evaluate(() => {
+      // Track print invocation from the page script click handler.
+      ;(window as Window & { __printInvoked?: boolean }).__printInvoked = false
+      window.print = () => {
+        ;(window as Window & { __printInvoked?: boolean }).__printInvoked = true
+      }
+    })
+
+    await printReplyPage.printButton().click()
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => (window as Window & { __printInvoked?: boolean }).__printInvoked === true),
+      )
+      .toBe(true)
+  })
+
+  test('should capture the printable reply template content', async ({ page, signIn }) => {
+    test.skip(!isWiremock, 'Requires WireMock stubs')
+
+    const closedApplication = { ...app, status: APPLICATION_STATUS.APPROVED }
+    await visitApplicationPage({ page, signIn, application: closedApplication })
+    await managingPrisonerAppsApi.stubGetAppResponse({ app: closedApplication, decision: 'APPROVED' })
+
+    const viewApplicationPage = new ViewApplicationPage(page)
+    await viewApplicationPage.printReplyTab().click()
+
+    const printReplyPage = new PrintReplyPage(page)
+    await printReplyPage.checkOnPage()
+
+    await expect(printReplyPage.printableTemplate()).toHaveCount(1)
+
+    const printableTemplateHtml = await printReplyPage.printableTemplate().evaluate(node => node.outerHTML)
+    await test.info().attach('print-reply-template.html', {
+      body: Buffer.from(printableTemplateHtml, 'utf-8'),
+      contentType: 'text/html',
+    })
+
+    const printableTemplateText = await printReplyPage.printableTemplate().innerText()
+    await expect(printReplyPage.printableTemplate()).toContainText('Your application has been approved.')
+    expect(printableTemplateText).toContain('Application type')
+    expect(printableTemplateText).toContain('Status')
+    expect(printableTemplateText).toContain('Reason')
+    expect(printableTemplateText).toContain('Business Hub')
+  })
 })

--- a/integration_tests/specs/view-application-details.spec.ts
+++ b/integration_tests/specs/view-application-details.spec.ts
@@ -1,7 +1,14 @@
 import { expect, test } from '../fixtures'
 import { app } from '../../server/testData'
+import ForwardApplicationPage from '../pages/forwardApplicationPage'
 import ViewApplicationPage from '../pages/viewApplicationPage'
 import { filteredApplicationTypes, visitApplicationPage } from './view-applicationTestUtils'
+import {
+  assertAndCaptureHistoryEvents,
+  getForwardTargetDepartment,
+  stubForwardFlowStateTransition,
+  stubForwardHistoryEvents,
+} from './view-application-forward-history-helper'
 
 filteredApplicationTypes.forEach(({ name, id }) => {
   test.describe(`View Application Page - ${name}`, () => {
@@ -132,5 +139,49 @@ test.describe('View Application Page - Forward button visibility', () => {
 
     const viewPage = new ViewApplicationPage(page)
     await expect(viewPage.forwardApplication()).not.toBeVisible()
+  })
+
+  test('should forward from application page and update the department details section', async (
+    { page, signIn },
+    testInfo,
+  ) => {
+    await visitApplicationPage({ page, signIn, application, departmentCount: 2 })
+
+    const viewPage = new ViewApplicationPage(page)
+    await expect(viewPage.department()).toContainText('Business Hub')
+    await expect(viewPage.forwardApplication()).toBeVisible()
+
+    await viewPage.forwardApplication().click()
+
+    const forwardPage = new ForwardApplicationPage(page)
+    await expect(forwardPage.pageTitle()).toContainText('Forward this application')
+
+    const targetDepartment = await getForwardTargetDepartment(page, forwardPage)
+    const forwardedApplication = await stubForwardFlowStateTransition({
+      application,
+      targetDepartment,
+    })
+
+    await forwardPage.selectDepartment(targetDepartment.value)
+    await forwardPage.enterForwardingReason('Forwarding to a new department')
+    await forwardPage.submit()
+
+    await expect(page).toHaveURL(new RegExp(`/applications/${application.requestedBy.username}/${application.id}`))
+    await expect(page.getByText(`Application forwarded to ${targetDepartment.name}`)).toBeVisible()
+    await expect(viewPage.department()).toContainText(targetDepartment.name)
+
+    await stubForwardHistoryEvents({
+      application,
+      forwardedApplication,
+      targetDepartment,
+    })
+
+    await assertAndCaptureHistoryEvents({
+      page,
+      viewPage,
+      application,
+      targetDepartment,
+      testInfo,
+    })
   })
 })

--- a/integration_tests/specs/view-application-details.spec.ts
+++ b/integration_tests/specs/view-application-details.spec.ts
@@ -141,10 +141,10 @@ test.describe('View Application Page - Forward button visibility', () => {
     await expect(viewPage.forwardApplication()).not.toBeVisible()
   })
 
-  test('should forward from application page and update the department details section', async (
-    { page, signIn },
-    testInfo,
-  ) => {
+  test('should forward from application page and update the department details section', async ({
+    page,
+    signIn,
+  }, testInfo) => {
     await visitApplicationPage({ page, signIn, application, departmentCount: 2 })
 
     const viewPage = new ViewApplicationPage(page)

--- a/integration_tests/specs/view-application-forward-history-helper.ts
+++ b/integration_tests/specs/view-application-forward-history-helper.ts
@@ -1,0 +1,155 @@
+import { expect, Page, TestInfo } from '@playwright/test'
+import { app } from '../../server/testData'
+import managingPrisonerAppsApi from '../mockApis/managingPrisonerApps'
+import { stubFor } from '../mockApis/wiremock'
+import ForwardApplicationPage from '../pages/forwardApplicationPage'
+import ViewApplicationPage from '../pages/viewApplicationPage'
+
+export type ForwardTarget = {
+  value: string
+  name: string
+}
+
+export const getForwardTargetDepartment = async (
+  page: Page,
+  forwardPage: ForwardApplicationPage,
+): Promise<ForwardTarget> => {
+  const targetDepartmentRadio = forwardPage.departmentRadios().nth(1)
+  const targetDepartmentId = await targetDepartmentRadio.getAttribute('id')
+  const targetDepartmentValue = await targetDepartmentRadio.getAttribute('value')
+  const targetDepartmentName = (await page.locator(`label[for="${targetDepartmentId}"]`).innerText()).trim()
+
+  return {
+    value: targetDepartmentValue,
+    name: targetDepartmentName,
+  }
+}
+
+export const stubForwardFlowStateTransition = async ({
+  application,
+  targetDepartment,
+}: {
+  application: typeof app
+  targetDepartment: ForwardTarget
+}) => {
+  const forwardedApplication = {
+    ...application,
+    assignedGroup: {
+      ...application.assignedGroup,
+      id: targetDepartment.value,
+      name: targetDepartment.name,
+    },
+  }
+
+  await stubFor({
+    priority: 1,
+    scenarioName: 'forward-application-flow',
+    requiredScenarioState: 'Started',
+    newScenarioState: 'FORWARDED',
+    request: {
+      method: 'POST',
+      urlPathPattern: `/managingPrisonerApps/v1/apps/${application.id}/forward/groups/.*`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+    },
+  })
+
+  await stubFor({
+    priority: 1,
+    scenarioName: 'forward-application-flow',
+    requiredScenarioState: 'FORWARDED',
+    request: {
+      method: 'GET',
+      url: `/managingPrisonerApps/v1/prisoners/${application.requestedBy.username}/apps/${application.id}?requestedBy=true&assignedGroup=true`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: forwardedApplication,
+    },
+  })
+
+  return forwardedApplication
+}
+
+export const stubForwardHistoryEvents = async ({
+  application,
+  forwardedApplication,
+  targetDepartment,
+}: {
+  application: typeof app
+  forwardedApplication: typeof app
+  targetDepartment: ForwardTarget
+}) => {
+  await managingPrisonerAppsApi.stubGetComments({ app: forwardedApplication })
+  await stubFor({
+    request: {
+      method: 'GET',
+      url: `/managingPrisonerApps/v1/prisoners/${application.requestedBy.username}/apps/${application.id}/history`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: [
+        {
+          id: 'history-item-logged',
+          appId: application.id,
+          entityId: application.assignedGroup.id,
+          entityType: 'ASSIGNED_GROUP',
+          activityMessage: {
+            header: 'Application logged',
+            createdBy: 'John Doe',
+            body: `Assigned to ${application.assignedGroup.name}`,
+          },
+          createdDate: '2026-07-10T10:00:00.000Z',
+        },
+        {
+          id: 'history-item-forwarded',
+          appId: application.id,
+          entityId: targetDepartment.value,
+          entityType: 'ASSIGNED_GROUP',
+          activityMessage: {
+            header: 'Application forwarded',
+            createdBy: 'John Doe',
+            body: `Forwarded to ${targetDepartment.name}`,
+          },
+          createdDate: '2026-07-10T10:00:30.000Z',
+        },
+      ],
+    },
+  })
+}
+
+export const assertAndCaptureHistoryEvents = async ({
+  page,
+  viewPage,
+  application,
+  targetDepartment,
+  testInfo,
+}: {
+  page: Page
+  viewPage: ViewApplicationPage
+  application: typeof app
+  targetDepartment: ForwardTarget
+  testInfo: TestInfo
+}) => {
+  await viewPage.historyTab().click()
+
+  await expect(page).toHaveURL(new RegExp(`/applications/${application.requestedBy.username}/${application.id}/history`))
+  await expect(page.getByText('History of this application')).toBeVisible()
+  await expect(page.getByText('Application logged')).toBeVisible()
+  await expect(page.getByText(`Assigned to ${application.assignedGroup.name}`)).toBeVisible()
+  await expect(page.getByText('Application forwarded')).toBeVisible()
+  await expect(page.getByText(`Forwarded to ${targetDepartment.name}`)).toBeVisible()
+
+  const historyEvents = await page
+    .locator('.moj-timeline__item')
+    .evaluateAll(items => items.map(item => item.textContent?.trim() || ''))
+
+  await testInfo.attach('history-events.txt', {
+    body: Buffer.from(historyEvents.join('\n\n'), 'utf-8'),
+    contentType: 'text/plain',
+  })
+}

--- a/integration_tests/specs/view-application-forward-history-helper.ts
+++ b/integration_tests/specs/view-application-forward-history-helper.ts
@@ -137,7 +137,9 @@ export const assertAndCaptureHistoryEvents = async ({
 }) => {
   await viewPage.historyTab().click()
 
-  await expect(page).toHaveURL(new RegExp(`/applications/${application.requestedBy.username}/${application.id}/history`))
+  await expect(page).toHaveURL(
+    new RegExp(`/applications/${application.requestedBy.username}/${application.id}/history`),
+  )
   await expect(page.getByText('History of this application')).toBeVisible()
   await expect(page.getByText('Application logged')).toBeVisible()
   await expect(page.getByText(`Assigned to ${application.assignedGroup.name}`)).toBeVisible()


### PR DESCRIPTION
- Add tests for forwarding applications to another department
<img width="3450" height="2026" alt="image" src="https://github.com/user-attachments/assets/8b3f35c8-44ae-42a6-b1f4-bb2a54023733" />
<img width="3444" height="2046" alt="image" src="https://github.com/user-attachments/assets/14a3e2b9-48bf-4119-a163-38bbfa25982c" />

- Add test coverage for Print and reply module
<img width="3448" height="2034" alt="image" src="https://github.com/user-attachments/assets/46fd0ce7-c1c9-4296-9ae9-88c3a359e33f" />

- Add stub helper for application forwarding
- Add History coverage for forward to department event
<img width="1729" height="1026" alt="image" src="https://github.com/user-attachments/assets/7dbc9eb4-5568-48b6-8863-bcc53da0dbbe" />
